### PR TITLE
ci: Remove invalid maven publication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,14 +133,6 @@ allprojects {
 }
 
 publishing {
-    publications {
-        maven(MavenPublication) {
-            groupId = 'io.github.bensku'
-            artifactId = 'java-ts-bind'
-            version = '1.0.0-jahia-3'
-            from components.java
-        }
-    }
     repositories {
         maven {
             name = "jahia-releases"


### PR DESCRIPTION
Remove left-over from a copy-paste (https://github.com/Jahia/java-ts-bind/blob/master/build.gradle#L13-L17) that prevents the release workflow to complete (but the artifact is still published to the _jahia-releases_ repository.